### PR TITLE
Updated reference to distro to use master instead of release v1.0.0

### DIFF
--- a/cnf/ext/enroute-distro.bnd
+++ b/cnf/ext/enroute-distro.bnd
@@ -9,7 +9,7 @@
 -plugin.enroute.distro = \
 	aQute.bnd.deployer.repository.FixedIndexedRepo; \
 	        name		=       Distro; \
-	        locations	=       https://raw.githubusercontent.com/osgi/osgi.enroute/v1.0.0/cnf/distro/index.xml
+	        locations	=       https://raw.githubusercontent.com/osgi/osgi.enroute/master/cnf/distro/index.xml
 	        
 
 -runblacklist.enroute:	\


### PR DESCRIPTION
PR is also made for corresponding updates in osgi.enroute.